### PR TITLE
Fix dataset path and model __str__

### DIFF
--- a/celery_app/crawlers/symptoms.py
+++ b/celery_app/crawlers/symptoms.py
@@ -48,7 +48,7 @@ def get_paragraph(browser: Chrome, symptom: str, department: str):
 
 @app.task()
 def period_send_symptom_crawler_task():
-    dataset_path = pathlib.Path(__file__).parent / "datasets.json"
+    dataset_path = pathlib.Path(__file__).resolve().parent.parent / "datasets" / "datasets.json"
     with open(dataset_path, "r", encoding="utf-8") as f:
         for dataset in json.load(f):
             symptom_crawler_task(

--- a/symptoms/models.py
+++ b/symptoms/models.py
@@ -25,4 +25,4 @@ class Symptom(models.Model):
     )
 
     def __str__(self):
-        return self.id
+        return str(self.id)


### PR DESCRIPTION
## Summary
- correct dataset path for Celery crawler
- fix Symptom model string representation

## Testing
- `python -m py_compile $(git ls-files '*.py')`